### PR TITLE
Corrige exibição da lista "Navegação" do rodapé

### DIFF
--- a/app/Views/layouts/main.php
+++ b/app/Views/layouts/main.php
@@ -374,19 +374,19 @@
 				<div class="col-md-6 col-lg-3 mb-4">
 					<h5 class="mb-4">Navegação</h5>
 					<div class="row">
-						<div class="col-6">
+						<div class="col-12">
 							<ul class="nav flex-column">
 								<li class="nav-item"><a class="mb-2" href="<?= site_url('site/artigos'); ?>">Artigos</a>
 								</li>
 							</ul>
 						</div>
-						<div class="col-6">
+						<div class="col-12">
 							<ul class="nav flex-column">
 								<li class="nav-item"><a class="mb-2" href="<?= site_url('site/contato'); ?>">Contato</a>
 								</li>
 							</ul>
 						</div>
-						<div class="col-6">
+						<div class="col-12">
 							<ul class="nav flex-column">
 								<li class="nav-item"><a class="mb-2" href="<?= site_url('links'); ?>">Todos os projetos</a>
 								</li>


### PR DESCRIPTION
Antes:
![image](https://github.com/user-attachments/assets/c2f7fbbe-e6ea-4c62-be2a-2c4c7a6a6fc9)

Depois:
![image](https://github.com/user-attachments/assets/739c547e-16ae-43b9-8672-f860ef92e221)
