### PR TITLE
feat: add RSS feed and sitemap.xml endpoints with Dockerfile optimiza…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,7 @@ RUN docker-php-ext-install \
     intl \
     ctype \
     tokenizer \
-    xmlwriter \
-    openssl
+    xmlwriter
 
 # Xdebug
 RUN pecl install xdebug && docker-php-ext-enable xdebug

--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -32,6 +32,10 @@ $routes->setAutoRoute(true);
 $routes->get('/', 'Site::index');
 $routes->get('links', 'Site::links');
 
+// RSS and Sitemap routes
+$routes->get('rss', 'Rss::index');
+$routes->get('sitemap.xml', 'Sitemap::index');
+
 /*
  * --------------------------------------------------------------------
  * Additional Routing

--- a/app/Controllers/Rss.php
+++ b/app/Controllers/Rss.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Controllers;
+
+use App\Models\ArtigosModel;
+use Laminas\Feed\Writer\Feed;
+
+class Rss extends BaseController
+{
+    protected $artigosModel;
+
+    public function __construct()
+    {
+        $this->artigosModel = new ArtigosModel();
+    }
+
+    public function index()
+    {
+        // Get published articles (fase_producao_id in 6,7 and not discarded)
+        $artigos = $this->artigosModel
+            ->select('artigos.id, artigos.titulo, artigos.url_friendly, artigos.texto, artigos.imagem, artigos.publicado, colaboradores.apelido as autor')
+            ->join('colaboradores', 'colaboradores.id = artigos.escrito_colaboradores_id')
+            ->whereIn('artigos.fase_producao_id', [6, 7])
+            ->where('artigos.descartado IS NULL')
+            ->orderBy('artigos.publicado', 'DESC')
+            ->limit(50) // Limit to last 50 articles
+            ->get()
+            ->getResultArray();
+
+        // Create RSS feed using Laminas Feed
+        $feed = new Feed();
+        $feed->setTitle('Visão Libertária - RSS Feed');
+        $feed->setDescription('Últimos artigos publicados no site Visão Libertária');
+        $feed->setLink(base_url());
+        $feed->setDateModified(time());
+        $feed->setLanguage('pt-BR');
+        $feed->setGenerator('Visão Libertária CMS');
+
+        foreach ($artigos as $artigo) {
+            $entry = $feed->createEntry();
+            $entry->setTitle($artigo['titulo']);
+            $entry->setDescription(strip_tags(substr($artigo['texto'], 0, 500)) . '...');
+            $entry->setLink(base_url('site/artigo/' . $artigo['url_friendly']));
+            $entry->setDateCreated(strtotime($artigo['publicado']));
+            $entry->setDateModified(strtotime($artigo['publicado']));
+            $entry->setAuthor([
+                'name' => $artigo['autor']
+            ]);
+
+            // Add enclosure if image exists
+            if (!empty($artigo['imagem'])) {
+                $entry->addEnclosure([
+                    'uri' => $artigo['imagem'],
+                    'type' => 'image/jpeg',
+                    'length' => 0
+                ]);
+            }
+
+            $feed->addEntry($entry);
+        }
+
+        // Set content type as RSS
+        $this->response->setContentType('application/rss+xml');
+
+        return $this->response->setBody($feed->export('rss'));
+    }
+}

--- a/app/Controllers/Sitemap.php
+++ b/app/Controllers/Sitemap.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace App\Controllers;
+
+use App\Models\ArtigosModel;
+use App\Models\ProjetosModel;
+use App\Models\ProjetosVideosModel;
+use App\Models\PaginasEstaticasModel;
+use App\Models\ColaboradoresModel;
+use RumenX\Sitemap\Sitemap;
+use RumenX\Sitemap\Url;
+
+class Sitemap extends BaseController
+{
+    protected $artigosModel;
+    protected $projetosModel;
+    protected $projetosVideosModel;
+    protected $paginasEstaticasModel;
+    protected $colaboradoresModel;
+
+    public function __construct()
+    {
+        $this->artigosModel = new ArtigosModel();
+        $this->projetosModel = new ProjetosModel();
+        $this->projetosVideosModel = new ProjetosVideosModel();
+        $this->paginasEstaticasModel = new PaginasEstaticasModel();
+        $this->colaboradoresModel = new ColaboradoresModel();
+    }
+
+    public function index()
+    {
+        // Create a new sitemap instance
+        $sitemap = new Sitemap();
+
+        // Add static pages
+        $sitemap->addUrl(new Url([
+            'loc' => base_url(),
+            'lastmod' => date('Y-m-d'),
+            'changefreq' => 'daily',
+            'priority' => '1.0'
+        ]));
+        
+        $sitemap->addUrl(new Url([
+            'loc' => base_url('site/artigos'),
+            'lastmod' => date('Y-m-d'),
+            'changefreq' => 'daily',
+            'priority' => '0.9'
+        ]));
+        
+        $sitemap->addUrl(new Url([
+            'loc' => base_url('site/videos'),
+            'lastmod' => date('Y-m-d'),
+            'changefreq' => 'daily',
+            'priority' => '0.9'
+        ]));
+        
+        $sitemap->addUrl(new Url([
+            'loc' => base_url('site/links'),
+            'lastmod' => date('Y-m-d'),
+            'changefreq' => 'weekly',
+            'priority' => '0.7'
+        ]));
+        
+        $sitemap->addUrl(new Url([
+            'loc' => base_url('site/contato'),
+            'lastmod' => date('Y-m-d'),
+            'changefreq' => 'monthly',
+            'priority' => '0.6'
+        ]));
+
+        // Add published articles
+        $artigos = $this->artigosModel
+            ->select('artigos.url_friendly, artigos.publicado')
+            ->whereIn('artigos.fase_producao_id', [6, 7])
+            ->where('artigos.descartado IS NULL')
+            ->orderBy('artigos.publicado', 'DESC')
+            ->get()
+            ->getResultArray();
+
+        foreach ($artigos as $artigo) {
+            $sitemap->addUrl(new Url([
+                'loc' => base_url('site/artigo/' . $artigo['url_friendly']),
+                'lastmod' => date('Y-m-d', strtotime($artigo['publicado'])),
+                'changefreq' => 'monthly',
+                'priority' => '0.8'
+            ]));
+        }
+
+        // Add projects and their videos (only if project has 'listar' = 'S')
+        $projetos = $this->projetosModel->where('listar', 'S')->findAll();
+
+        foreach ($projetos as $projeto) {
+            // Add project page
+            $sitemap->addUrl(new Url([
+                'loc' => base_url('site/videos/' . urlencode($projeto['nome'])),
+                'lastmod' => date('Y-m-d'),
+                'changefreq' => 'weekly',
+                'priority' => '0.7'
+            ]));
+
+            // Add videos from this project
+            $videos = $this->projetosVideosModel
+                ->where('projetos_id', $projeto['id'])
+                ->orderBy('publicado', 'DESC')
+                ->get()
+                ->getResultArray();
+
+            foreach ($videos as $video) {
+                $sitemap->addUrl(new Url([
+                    'loc' => cria_link_watch($video['video_id']),
+                    'lastmod' => date('Y-m-d', strtotime($video['publicado'])),
+                    'changefreq' => 'monthly',
+                    'priority' => '0.6'
+                ]));
+            }
+        }
+
+        // Add static pages
+        $paginasEstaticas = $this->paginasEstaticasModel
+            ->where('publico', 1) // Assuming there's a public field to determine if page should be indexed
+            ->orWhere('publico IS NULL') // Or if not set, assume public
+            ->findAll();
+
+        foreach ($paginasEstaticas as $pagina) {
+            $sitemap->addUrl(new Url([
+                'loc' => base_url('site/pagina/' . $pagina['url_friendly']),
+                'lastmod' => date('Y-m-d', strtotime($pagina['atualizado'])),
+                'changefreq' => 'weekly',
+                'priority' => '0.7'
+            ]));
+        }
+
+        // Add colaborador profiles (assuming public profiles)
+        $colaboradores = $this->colaboradoresModel
+            ->where('confirmado_data IS NOT NULL') // Only confirmed users
+            ->where('excluido IS NULL') // Not deleted
+            ->findAll();
+
+        foreach ($colaboradores as $colaborador) {
+            $sitemap->addUrl(new Url([
+                'loc' => base_url('site/escritor/' . urlencode($colaborador['apelido'])),
+                'lastmod' => date('Y-m-d', strtotime($colaborador['atualizado'])),
+                'changefreq' => 'weekly',
+                'priority' => '0.5'
+            ]));
+        }
+
+        // Set content type as XML
+        $this->response->setContentType('application/xml');
+
+        // Generate the sitemap XML
+        return $this->response->setBody($sitemap->generate());
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,9 @@
     "license": "MIT",
     "require": {
         "php": "^7.4 || ^8.0",
-        "codeigniter4/framework": "^4.0"
+        "codeigniter4/framework": "^4.0",
+        "laminas/laminas-feed": "^2.22",
+        "rumenx/php-sitemap": "^1.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9",


### PR DESCRIPTION
…tion

- Remove unused openssl extension from Dockerfile PHP configuration
- Add new RSS controller to generate RSS feed with latest published articles
- Add new Sitemap controller to generate XML sitemap with articles, projects, videos, static pages and collaborators
- Register /rss and /sitemap.xml routes in Routes configuration
- Implement article filtering for published content (fase_producao_id in 6,7 and not discarded)
- Add proper content types and XML formatting for both endpoints